### PR TITLE
FIX: Repairs broken link to Iñigo's repo in week 5 blogpost

### DIFF
--- a/posts/2024/2024_06_28_Inigo_week_5.rst
+++ b/posts/2024/2024_06_28_Inigo_week_5.rst
@@ -23,7 +23,7 @@ Also, they provided their code in TensorFlow, so I started adapting it to our us
 What is coming up next week
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-I will continue working on the conditional AutoEncoder next week, but you can see the progress `here <https://github.com/itellaetxe/tractoencoder_gsoc/blob/main/src/tractoencoder_gsoc/models/vae_model.py>`_.
+I will continue working on the conditional AutoEncoder next week, but you can see the progress `here <https://github.com/itellaetxe/tractoencoder_gsoc/blob/56ddacd8f9a2c6ac30a38c1c141bf60cc1b2d862/src/tractoencoder_gsoc/models/vae_model.py>`_.
 
 Did I get stuck anywhere
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/posts/2024/2024_06_28_Inigo_week_5.rst
+++ b/posts/2024/2024_06_28_Inigo_week_5.rst
@@ -23,7 +23,7 @@ Also, they provided their code in TensorFlow, so I started adapting it to our us
 What is coming up next week
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-I will continue working on the conditional AutoEncoder next week, but you can see the progress `here <https://github.com/itellaetxe/tractoencoder_gsoc/blob/main/src/tractoencoder_gsoc/models/cvae_model.py>`_.
+I will continue working on the conditional AutoEncoder next week, but you can see the progress `here <https://github.com/itellaetxe/tractoencoder_gsoc/blob/main/src/tractoencoder_gsoc/models/vae_model.py>`_.
 
 Did I get stuck anywhere
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The link pointing to the Variational Autoencoder Module in the tractoencoder_gsoc repo was pointing to an old file name in Iñigo's week 5 blogpost.

Updates the link to a file that won't be renamed.