### PR TITLE
DOC: GSOC call as blogpost

### DIFF
--- a/posts/2015/2015_01_15_eleftherios_gsoc_announcement.rst
+++ b/posts/2015/2015_01_15_eleftherios_gsoc_announcement.rst
@@ -1,0 +1,69 @@
+Google Summer of Code 2015 Announcement
+=======================================
+
+.. post:: January 15 2015
+     :author: Eleftherios Garyfallidis
+     :tags: google
+     :category: gsoc announcement
+
+We are happy to announce our application for the Google Summer of Code 2015. 
+
+If you are interested in participating as a student, please read `this <https://wiki.python.org/moin/SummerOfCode/Expectations>`_ first.
+
+GSoC is a project that enables students to learn by contributing to an open-source project, while receiving a stipend from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <http://www.google-melange.com/gsoc/homepage/google/gsoc2015>`_.
+
+All participants should have a basic knowledge of scientific programming in Python.
+Recommended book `Python for Data Analysis by Wes McKinney <http://shop.oreilly.com/product/0636920023784.do>`_. 
+
+Here are the projects we offer to mentor this summer:
+
+1. **3D visualizations**
+
+   Description: The main tool for 3D visualization in dipy is the dipy.viz.fvtk module. 
+   This creates `beautiful images <https://www.youtube.com/watch?v=kstL7KKqu94>`_, but the functionality is currently limited, and we would like to expand it. This project will create a more generic API that allows visualization of peaks, ODFs, volumes and streamlines in the correct space. Also implement VTK's network visualization in fvtk. Get creative! Many other things can be done here! For example enabling recording of 3D animations of the brain, create glass effects etc. 
+
+   Difficulty: high. 
+
+   Skills required: acquaintance with VTK is an advantage, knowledge of 3D graphics is required. 
+
+   Mentors: `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_ and `Ariel Rokem <mailto:arokem@gmail.com>`_ and `Matthew Brett <mailto:matthew.brett@gmail.com>`_.
+
+2. **Use directional information to improve dMRI registration**
+
+   Description: Currently in DIPY we have a framework for nonlinear registration based on the idea of Symmetric Normalization `SyN <http://www.ncbi.nlm.nih.gov/pubmed/17659998>`_. This framework allows to create new similarity metrics (e.g. cross correlation, or mutual information) and let the optimization of SyN to warp the images. Now, in diffusion MRI we can have in each voxel orientation distributions. The goal of the project is to use additionally this orientation information to drive the registration. So now we do not only warp but also re-orient the orientation distributions while warping. In other words, you will have to create a new orientation distribution based metric which will work inside our existing SyN framework. `This paper <http://www.ncbi.nlm.nih.gov/pubmed/21316463>`_ is a must read.
+
+   Difficulty: high 
+
+   Skills required: expertise in registration; acquaintance with diffusion modelling. 
+
+   Mentors: `Matthew Brett <mailto:matthew.brett@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_ and `Matthew Brett <mailto:matthew.brett@gmail.com>`_.  
+
+3. **Diffusion Kurtosis Imaging**
+
+   Description: `Diffusion Kurtosis Imaging <http://www.ncbi.nlm.nih.gov/pubmed/20632416>`_, or DKI, is a method that estimates the parameters of higher-order statistics in DWI data with multiple b-value measurements (such as measurements from the `Human Connectome Project <http://www.humanconnectome.org/>`_. This allows us to make inferences about properties of the tissue that are not readily available with other methods, such as DTI. We have already `begun <https://github.com/nipy/dipy/pull/233>`_ the work on an implementation of this algorithm, but the work needs to be completed, and there is still much to do here.
+
+   Difficulty: high. 
+   
+   Skills required: acquaintance with diffusion MRI. 
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_ and `Matthew Brett <mailto:matthew.brett@gmail.com>`_.
+
+4. **Offline quality assurance (QA) using a publicly available dataset**
+
+   Description: The ultimate demonstration of a tool is in its use in realistic and important cases. The analysis of high-quality publicly available data-sets (e.g. from the `Human Connectome Project <http://www.humanconnectome.org/>`_) is one compelling case. The goal of this project, is to create a pipeline for analysis of such a data-set, and to reproducibly execute this analysis as a way to benchmark the tools available through dipy, and perform QA, to detect regressions in the performance of these tools. This will also be a public show-case of the project, as a way to interest new users. 
+
+   Difficulty: intermediate. 
+
+   Skills required: acquaintance with diffusion MRI, and with dipy. 
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_ and `Matthew Brett <mailto:matthew.brett@gmail.com>`_.
+
+5. **Tissue classifiers for tracking**
+
+   Description: Research in the last couple of years has shown that using a tissue classifier in tracking can be of great benefit for creating more accurate representations of the underlying white matter anatomy. The goal of this project will be to create accurate tissue classifiers to guide tracking. So this is basically an image segmentation task. To do that, we will have to implement a couple of popular algorithms using T1-weighted and/or invent a new one using DWI data. Sounds fun?
+
+   Difficulty: intermediate. 
+
+   Skills required: acquaintance with diffusion MRI and image segmentation. 
+
+   Mentors: `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_ and `Ariel Rokem <mailto:arokem@gmail.com>`_ and `Matthew Brett <mailto:matthew.brett@gmail.com>`_

--- a/posts/2016/2016_02_01_eleftherios_gsoc_announcement.rst
+++ b/posts/2016/2016_02_01_eleftherios_gsoc_announcement.rst
@@ -1,0 +1,94 @@
+How to become a part of DIPY's Google Summer of Code 2016
+=========================================================
+
+.. post:: February 01 2016
+     :author: Eleftherios Garyfallidis
+     :tags: google
+     :category: gsoc announcement
+
+GSoC is a program that allows students to learn by contributing to an open-source project, while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://developers.google.com/open-source/gsoc/>`_.
+
+Before considering becoming part of the Dipy GSoC, please read about our `expectations <https://wiki.python.org/moin/SummerOfCode/Expectations>`_. 
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. 
+
+Projects
+--------
+
+1. **Continuous quality assurance (QA) in cloud computing environment**
+
+   Description: The ultimate demonstration of a tool is in its use in realistic and important cases. The analysis of high-quality publicly available data-sets (e.g. from the `Human Connectome Project <http://www.humanconnectome.org/>`_) is one compelling case. The goal of this project, is to create a pipeline for analysis of such a data-set, and to reproducibly execute this analysis on a cloud computing resource, as a way to benchmark the tools available through dipy, and perform QA, to detect regressions in the performance of these tools. This will also be a public show-case of the project, as a way to interest new users. 
+
+   Difficulty: intermediate. 
+
+   Skills required: acquaintance with diffusion MRI, and with dipy. Acquaintance with cloud computing is a plus.
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_.
+
+2. **CHARMED: biophysical modeling of multi b-value data**
+    
+   Description: The `CHARMED model <http://www.ncbi.nlm.nih.gov/pubmed/15979342>`_ describes the diffusion signal as a combination of hindered and restricted components. This advanced model, when applied to data with multiple b-values, can be used to make inferences about tissue structure and biophysics. The GSoC project will focus on an efficient and well-tested implementation of the CHARMED model in the Dipy reconstruction module. 
+
+   Difficulty: intermediate
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_ and Rafael Henriques.
+
+3. **Develop a new DIPY website with more interactive features (project is full)**
+
+   Description: The current `DIPY <http://dipy.org>`_ website is based on Sphinx and allows for only one documentation to be online (the development version). One of the tasks of this project will be to create a new github repository which will be only for Dipy's website. Right now the website is under the doc folder of the dipy repository. In this new repository a new responsive website will be created which upon other things will allow for hosting documentations for multiple versions. Additionally, the new website will allow for direct insertion of news and connections and updates to social media. Most importantly, new algorithms are expected to be developed that will increase UX. More details soon.
+ 
+   Difficulty: intermediate
+
+   Skills required: Django, bootstrap, javascript, sphinx and expertise in web development
+
+   Project is full: We had already more than 40 excellent people applying for this project and it will be impossible to interview more of them. **So, this specific project is now closed for new applicants, contacting us after 2nd of March**. Please look and apply to the other exciting projects. 
+
+   Mentors: `Jean-Christophe Houde <mailto:jean.christophe.houde@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+
+4. **DKI enhancements**
+
+   Description: diffusion kurtosis imaging (DKI) is an extension of the classic DTI model. In the previous GSoC, `Rafael Henriques implemented the DKI model fitting and estimation <http://gsoc2015dipydki.blogspot.com/>`_. This project proposes to extend our current implementation of diffusion kurtosis with a few different improvements. The first extension will allow us to estimate additional parameters of white matter "integrity" based on the diffusion kurtosis model (see `Fieremans et al. paper <http://www.sciencedirect.com/science/article/pii/S1053811911006148>`_). The second extension will allow us to use the DKI model for tractography (see `tractography paper <http://www.ncbi.nlm.nih.gov/pubmed/26275886>`_). Finally, we will also implement the REKINDLE algorithm, which allows robust fitting of DKI parameters (see `REKINDLE paper <http://onlinelibrary.wiley.com/doi/10.1002/mrm.25165/abstract>`_).
+
+   Difficulty: high -- knowledge in diffusion MRI preferred
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_ and Rafael Henriques
+
+5. **IVIM: Simultaneous modeling of perfusion and diffusion**
+
+   Description: The IVIM model uniquely describes the diffusion and perfusion from data with multiple b-values (see `Le Bihan et al. paper <http://pubs.rsna.org/doi/abs/10.1148/radiology.161.2.3763909>`_ or `Luciani et al. paper <http://onlinelibrary.wiley.com/doi/10.1002/jmri.24195/full>`_). It has been used to investigate brain disease, stroke, aging, and liver fibrosis among other medical and neuroscience applications. This project proposes porting a `previous implementation of IVIM processing by Eric Peterson <https://github.com/etpeterson/IVIM_fitting>`_ into Dipy. Further extensions would be to implement the Jacobian for speed improvements in the nonlinear fitting and improvements in the fitting algorithm to improve robustness.
+
+   Difficulty: intermediate
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_, Eric Peterson and `Rafael Henriques <mailto:rafaelnh21@gmail.com>`_.
+
+6. **Scifi UI using Python-VTK in DIPY.VIZ**
+
+   Description: The main idea will be to develop new futuristic widgets directly using VTK (Visualization Toolkit) without calling any external libraries. So, no Qt! Only VTK which is written already in OpenGL. Here are some recent tutorials to have a look http://dipy.org/examples_index.html#id15 and start playing with.
+   Those new widgets are useful because we want to use them to navigate in tractographies and allow neurosurgeons and other neuroscientists to have a unique impression and user experience when using our tools. We also want to be lightweight and as multiplaform as possible.
+   Have you watched Guardians of the Galaxy? We want to create with this project the very basic tools so that in some years, we can do something like that https://vimeo.com/103533906 but of course applied for tractography exploration not for space travelling. For example, some of the tasks will be to develop a filedialogue, a sliding panel with buttons and add dynamic actor menus (3D menus on objects - like in games). 
+
+   Difficulty: high
+
+   Skills required: Python, OpenGL and VTK
+
+   Mentors: `Marc-Alexandre Côté <mailto:marc.cote.19@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+    
+7. **Automatic denoising and robust brain extraction**
+
+   Description: Create a method for automatic denoising of diffusion MRI and structural MR datasets. Currently we need to estimate the noise of the signal which is often a bit troublesome. Local PCA will be the main method to try to implement in this project but the harder task will be to do so efficiently in Python/Cython without extra dependencies. After implementing this method, the next task will be to create a more robust brain extraction method from what is currently implemented in DIPY. For this task the student will have to think of his own strategies and take decisions on which methods to combine or implement to do so. 
+
+   Difficulty: high
+
+   Skills required: Python, Numpy, diffusion MRI, signal processing, DIPY
+
+   Mentors: `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_, Omar Ocegueda, `Julio Villalon <mailto:jevillalonr@gmail.com>`_ and `Rafael Henriques <mailto:rafaelnh21@gmail.com>`_.
+
+8. **Eddy current correction**
+
+   Description: Eddy currents are artifacts that affect diffusion MRI measurements. A common preprocessing step is to correct for these artifacts. In this project, we will implement a `popular algorithm for eddy current correction <http://www.ncbi.nlm.nih.gov/pubmed/14705050>`_.
+
+   Difficulty: moderate
+
+   Skills required: Familiarity with diffusion MRI, numpy, scipy.
+
+   Mentors: `Ariel Rokem <mailto:arokem@gmail.com>`_ and Bob Dougherty.

--- a/posts/2018/2018_01_24_eleftherios_gsoc_announcement.rst
+++ b/posts/2018/2018_01_24_eleftherios_gsoc_announcement.rst
@@ -1,0 +1,157 @@
+Google Summer of Code 2018
+==========================
+
+.. post:: January 24 2018
+     :author: Eleftherios Garyfallidis
+     :tags: google
+     :category: gsoc announcement
+
+Introduction to DIPY
+====================
+
+DIPY is a free and open source software library for computational neuroanatomy and medical data science. DIPY contains algorithms for diffusion magnetic resonance imaging (dMRI) analysis and tractography but also contains implementations of other computational imaging methods such as denoising and registration that are applicable to the greater medical imaging and image processing communities. Additionally, DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging. DIPY is participating in GSoC this year for the 3rd time under the umbrella of the Python Software Foundation (PSF).
+
+How to become a part of DIPY's Google Summer of Code 2018
+=========================================================
+
+GSoC is a program that allows students to learn by contributing to an open-source project, while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://developers.google.com/open-source/gsoc/>`_.
+
+Before considering becoming part of the DIPY GSoC, please read about our `expectations <https://wiki.python.org/moin/SummerOfCode/Expectations>`_. 
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. 
+However, you should be already familiar with data analysis using Python and Numpy before applying.
+
+Be happy to ask questions directly in our Gitter channel https://gitter.im/nipy/dipy
+
+Advice
+------
+
+Potential candidates should take a look at the guidelines on `how to contribute to DIPY <https://github.com/nipy/dipy/blob/master/CONTRIBUTING.md>`_. Making a small enhancement/bugfix/documentation fix/etc to DIPY already before applying for the GSoC is a requirement from the PSF; it can help you get some idea how things would work during the GSoC. The fix does not need to be related to your proposal. We have and will continue adding some beginner friendly issues in github.
+
+Projects
+========
+
+1. **DIPY workflows and Quality Assurance**
+
+   Description: Create new dipy.workflows and make those executable in different platforms. DIPY has a unique 
+   system that allows to create command line interfaces in a systematic and precise way to run across platforms.
+   DIPY uses existing technology such as the default argument parser of Python but enhances the parser using a 
+   software engineering process called introspection. Our IntrospectiveParser allows to generate workflows that 
+   can be executed both by the command line and using Python scripts. In this work, you will have to: 
+
+   * Take existing tutorials and generate new workflows from them. Test the workflows with new data and generate 
+     automated reports.
+
+   * Help with simplifying installation in the different operating systems.  
+
+   Difficulty: easy to intermediate
+
+   Skills required: Numpy, Python, pyinstaller (or similar), medical imaging. 
+
+   Mentors: `Serge Koudoro <mailto:skab12@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+
+2. **Extend Visualization - Focus in UI**
+ 
+   Description: In this project you will build scifi-like 3D and 2D user interfaces inspired from Guardians of 
+   the Galaxy `video <https://www.youtube.com/watch?v=b0ve2nHEVWw>`_. Dipy.viz provides many visualization 
+   capabilities. However we were not happy with interactive capabilities found in existing GUIs. For this reason 
+   we built our own UI engine. No Qt! Everything is integrated in the VTK scene. See example below that was 
+   generated during our 2016 GSoC participation. This is an example of an orbital orbital menu.
+
+   .. image:: http://i.giphy.com/b0pJ7djNSIWFa.gif
+      :align: center
+
+   In this project you will extend this work and add more futuristic widgets. The motto of this project is make 
+   everything interactive without performance issues. See also figure of Project 5.
+
+   Difficulty: intermediate
+
+   Skills required: Python, OpenGL and VTK
+
+   Mentors: `David Reagan <mailto:dmreagan@iu.edu>`_ and `Ranveer Aggarwal <mailto:ranveeraggarwal@gmail.com>`_ and 
+   `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+
+3. **Improve performance of nonrigid image registration**
+    
+   Description: We have some really nice code for nonrigid registration that needs to be parallelized. The code 
+   is written in Python and Cython. You will need to work primarily on adding multithreading (OpenMP) 
+   capabilities in our Symmetric Normalization framework. Start by playing with the following tutorials
+
+   https://github.com/nipy/dipy/blob/master/doc/examples/affine_registration_3d.py
+   https://github.com/nipy/dipy/blob/master/doc/examples/syn_registration_2d.py
+   https://github.com/nipy/dipy/blob/master/doc/examples/syn_registration_3d.py
+
+   Difficulty: intermediate. 
+
+   Skills required: Familiarity with OpenMP, Cython, Python, Numpy. 
+
+   Mentor: `Serge Koudoro <mailto:skab12@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+
+4. **Extend Clustering Framework**
+
+   Description: QuickBundles and QuickBundlesX are extremely fast algorithms that can be used in a series of 
+   fields and datasets. We initially used this algorithm to cluster streamlines. Your job will be to extend our 
+   existing framework to new datasets. For, example implement new metrics that allow to cluster surfaces, 
+   images, text or other. Also, you will have to work on a research component of the algorithm that is related 
+   to reducing the number of clusters in dense datasets.   
+
+   Difficulty: intermediate
+
+   Skills required: Python/Cython, machine learning. Especially, unsupervised learning. Knowledge of scikit-
+   learn is an advantage. 
+
+   Mentor: `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_ and `Serge Koudoro <mailto:skab12@gmail.com>`_
+
+5. **Extend Visualization - Focus in GLSL**
+     
+   Description: Our new visualization engine supports GLSL shading language. Join our effort to built stunning 
+   visualizations of brain images and other scientific datasets. You will have to program vertex and fragment 
+   shaders to generate different effects on VTK polydata. For examples, see code `here <https://github.com/dmreagan/vtk-shaders>`_. Here is an example without shaders 
+
+   .. image:: https://media.giphy.com/media/l49JEQvtIForHhvlC/giphy.gif
+      :width: 600
+      :height: 400
+      :align: center
+
+   You will have to update the code to enable shading when needed and if supported by the current computing 
+   system. Please also check tutorials starting with viz here 
+
+   https://github.com/nipy/dipy/tree/master/doc/examples
+
+   Difficulty: high
+
+   Skills required: GLSL, Python, OpenGL and VTK
+
+   Mentors: `David Reagan <mailto:dmreagan@iu.edu>`_, `Ranveer Aggarwal <mailto:ranveeraggarwal@gmail.com>`_ and 
+   `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+
+6. **Implement new models for microstructure imaging**
+
+   Description: This is a model fitting project. You will be required to extend our new microstructure 
+   framework. You will be able to implement models such as Multi Tensor, NODDI, Axcaliber, CHARMED, Ball & 
+   Sticks, Ball & Rackets all with three crossings and also all the combinations of Zeppelin, Cylinder, Dot and 
+   Ball compartments. See MRI example below. How would you model these tiny structures?
+
+   .. image:: https://media3.giphy.com/media/4F2eiACLhUaZy/giphy.gif
+      :width: 460
+      :height: 460
+      :align: center
+
+   Difficulty: high
+
+   Skills required: MSc or PhD level, mathematical optimization, Python, Numpy, Cython (bonus)
+   
+   Mentors: `Maryam Afzali <mailto:maryam.afzali.m@gmail.com>`_, `Mauro Zucchelli <mailto:mauro.zucchelli88@gmail.com>`_ and `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_
+
+7. **Extend and QA tracking framework**
+
+   Description: Tractography is one of the great challenges in medical imaging. In DIPY we have implemented 
+   different tracking algorithms including deterministic, probabilistic and particle filtering algorithms. You 
+   will have to extend dipy.tracking with machine learning based algorithms. Also you will need to test your 
+   algorithm with different datasets of different resolutions.
+
+   Difficulty: high
+
+   Skills required: Python/Cython, knowledge of tractography. Available only for MSc or PhD students.
+
+   Mentor: `Eleftherios Garyfallidis <mailto:garyfallidis@gmail.com>`_, `Serge Koudoro <mailto:skab12@gmail.com>`_, `Gabriel Girard <mailto:girard.gabriel@gmail.com>`_ and `Ariel Rokem <mailto:arokem@gmail.com>`_.

--- a/posts/2020/2020_02_05_serge_gsoc_announcement.rst
+++ b/posts/2020/2020_02_05_serge_gsoc_announcement.rst
@@ -1,0 +1,78 @@
+Google Summer of Code 2020
+==========================
+
+.. post:: February 05 2020
+     :author: Serge Koudoro
+     :tags: google
+     :category: gsoc announcement
+
+Introduction to DIPY
+====================
+
+DIPY is a free and open-source software library for the analysis of 3D/4D+ imaging in Python. It contains generic methods for spatial normalization, signal processing, machine learning, statistical analysis and visualization of medical images. Additionally, it contains specialized methods for computational anatomy including diffusion, perfusion, and structural imaging. DIPY has many users from computational neuroanatomy and medical data science field. DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging. DIPY is participating in GSoC this year for the 4th time.
+
+How to become a part of DIPY's Google Summer of Code 2020
+=========================================================
+
+GSoC is a program that allows students to learn by contributing to an open-source project while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://summerofcode.withgoogle.com/>`_. This year, DIPY is participating in GSoC under the umbrella of International Neuroinformatics Coordinating Facility (`INCF <https://www.incf.org/>`_). More information can be found at INCF's `GSoC 2020 page <https://www.incf.org/training/gsoc>`_.
+
+Before considering becoming part of the DIPY GSoC, please read about our expectations.
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. However, you should be already familiar with data analysis using Python and Numpy before applying.
+
+Be happy to ask questions directly in our Gitter channel https://gitter.im/nipy/dipy
+
+Advice
+------
+
+Potential candidates should take a look at the guidelines on how to `contribute to DIPY <https://github.com/dipy/dipy/blob/master/CONTRIBUTING.md>`_. Making a small enhancement/bugfix/documentation fix/etc to DIPY already before applying for the GSoC can help you get some idea how things would work during the GSoC. The fix does not need to be related to your proposal. We have and will continue adding some beginner-friendly issues in Github. You can see some of them `here <https://github.com/dipy/dipy/issues>`_.
+
+Projects
+========
+
+DIPY support for DICOM files
+----------------------------
+
+**Description:** Magnetic resonance imaging (MRI) is often stored in Digital Imaging and Communications in Medicine (DICOM) format. We want to provide DIPY users support for reading and writing to DICOM files. And also have an additional option to convert from DICOM to NIFTI file format.
+
+* Understand how DICOM file format works. 
+* Add support in DIPY to read and write DICOM files.
+* Understand and create a new DIPY command-line interface (Workflow).
+* Implement a robust DICOM to NIFTI conversion method.
+* (Optional) Create a workflow to connect and get data from a PACS server.
+
+**Difficulty:** Intermediate
+
+**Skills required:** Python/Cython, Medical Imaging. 
+
+**Mentors:** `Bramsh Chandio <mailto:bqchandi@iu.edu>`_ and `Eleftherios Garyfallidis <mailto:elef@indiana.edu>`_
+
+Machine learning-based MRI registration
+---------------------------------------
+
+**Description:** Develop a machine learning-based registration framework that makes use of the Diffeomorphic Registration implemented in DIPY. The goal is to train a CNN model that can compute the deformation field in an unsupervised setting. This project will also involve leveraging the reconstruction module in DIPY to perform image fusion via inter-modality registration.
+
+* Understand Diffeomorphic Registration. Look at ``dipy.align`` module and DIPY tutorial.
+* Understand advanced Image Reconstruction Models such as Free-Water-DTI, DKI, etc. in DIPY
+* Implement a Deep Neural Net (e.g. a 2D/ 3D CNN) or a Multivariate Model for Co-learning 
+
+**Difficulty:** High
+
+**Skills required:** Python, Deep Learning, Tensorflow, Registration, Strong Math Skills.
+
+**Mentors:** `Shreyas Fadnavis <mailto:shreyasfadnavis@gmail.com>`_ and `Bramsh Chandio <mailto:bqchandi@iu.edu>`_
+
+Extend DIPY Horizon workflow
+----------------------------
+
+**Description:** Extend ``dipy_horizon`` workflow by adding more options for the visualization of the diffusion data. DIPY Horizon is a workflow that enables to visualize diffusion data such as dMRI, tractograms, white matter bundles and more from command line. This project requires student to add support for different types of visualizations in the horizon workflow. 
+
+* Add support to visualize orientation distribution functions (odfs) generated from diffusion data
+* Create an option in the horizon workflow to project anatomical measures such as functional anisotropy (FA), mean diffusivity (MD), etc on the white matter tracts and visualize them
+* Add Qt functionality in dipy_horizon workflow
+
+**Difficulty:** Easy / Intermediate
+
+**Skills required:** Python, VTK, Qt. 
+
+**Mentors:** `Bramsh Chandio <mailto:bqchandi@iu.edu>`_ and `Eleftherios Garyfallidis <mailto:elef@indiana.edu>`_

--- a/posts/2020/2020_05_04_serge_gsod_announcement.rst
+++ b/posts/2020/2020_05_04_serge_gsod_announcement.rst
@@ -1,0 +1,102 @@
+Google Season of Docs 2020
+==========================
+
+.. post:: May 04 2020
+     :author: Serge Koudoro
+     :tags: google
+     :category: gsod announcement
+
+DIPY + FURY project ideas for GSoD'20
+=====================================
+
+Welcome, and thank you for showing your interest in `DIPY(Diffusion Imaging in Python) <https://dipy.org>`_ and `FURY(Free Unified Rendering in Python) <https://fury.gl>`_ projects! On this page, we will first provide more information about DIPY and FURY, then the current state of both projects' documentation, and we will finish by describing two project ideas in detail. We want to point out that you are more than welcome to bring your ideas; we'd love to discuss with you any ideas that improve our online presence or documentation.
+
+**Please note that** `the Google Season of Docs <https://developers.google.com/season-of-docs>`_ **is a program for writers with previous experience to show for the application. If you are a student, please consider** `Google Summer of Code <https://summerofcode.withgoogle.com>`_ **instead.**
+
+Technical Writers
+-----------------
+
+Welcome technical writers! Do not hesitate to contact us as early as possible! You can use any project chat channels for your first contact (see links on the documentation section). Also, you can find more information on the following links:
+
+- `Guidelines <https://developers.google.com/season-of-docs/docs/tech-writer-guide>`_
+- `Application Timeline <https://developers.google.com/season-of-docs/docs/timeline>`_
+- `How to write a good proposal <https://developers.google.com/season-of-docs/docs/tech-writer-application-hints>`_
+
+What are DIPY and FURY?
+-----------------------
+
+**About DIPY**: DIPY is a free and open-source software library for the analysis of 3D/4D+ imaging in Python. It contains generic methods for spatial normalization, signal processing, machine learning, statistical analysis, and visualization of medical images. Additionally, it contains specialized methods for computational anatomy including diffusion, perfusion, and structural imaging. DIPY has many users from the computational neuroanatomy and medical data science fields. DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging
+
+**About FURY**: FURY is a free and open-source software library for scientific visualization and 3D animations. FURY contains many tools for visualizing a series of scientific data including graph and imaging data. FURY is a DIPY spin-off.
+
+About our Documentation
+-----------------------
+
++-------------------+------------------------------------------------+------------------------------------------------+
+|                   | DIPY                                           | FURY                                           |
++===================+================================================+================================================+
+| Latest version    | https://dipy.org                               | https://fury.gl                                |
++-------------------+------------------------------------------------+------------------------------------------------+
+| tutorials         | https://dipy.org/tutorials/                    | http://fury.gl/latest/auto_tutorials/index.html|
++-------------------+------------------------------------------------+------------------------------------------------+
+| reference guide   | https://dipy.org/documentation/latest/reference| http://fury.gl/latest/reference/index.html     |
++-------------------+------------------------------------------------+------------------------------------------------+
+| developer docs    | https://dipy.org/documentation/latest/devel/   | http://fury.gl/latest/symlink/contributing.html|
++-------------------+------------------------------------------------+------------------------------------------------+
+| GitHub repository | https://github.com/dipy/dipy                   | https://github.com/fury-gl/fury                |
++-------------------+------------------------------------------------+------------------------------------------------+
+
+**The state of DIPY documentation**: We have complete reference documentation for most of the functions and classes exposed to users, although most of the functions are missing a usage example. Our User and Developer Guide needs to be updated and be made more consistent. Also, we need to create the documentation of our new CLI feature. Overall, offering a better experience will be valuable for our users!
+
+**The state of FURY documentation**: FURY is a recent project that offers flexibility. We have complete reference documentation for most functions, and an increasing number of tutorials have been created but FURY suffers from a lack of a Developer and User Guides.
+
+**DIPY + FURY documentation generation**: All our documentation and websites are built with `Sphinx <http://www.sphinx-doc.org>`_. Sphinx generates static websites (making them easy to deploy) and provides extensive functionality to transform plain-text *reStructuredText* documents to HTML, as well as extract and cross-link documentation automatically from docstrings in Python source code. Reference documentation follows the `NumPy docstring standard <https://numpydoc.readthedocs.io/en/latest/format.html>`_. A detailed guide on how to document functions, classes, and other objects can be found `here <https://www.numpy.org/devdocs/docs/howto_document.html>`_.
+
+Note for DIPY: A Django instance manages dynamic content and loads the static page generated by Sphinx.
+
+**DIPY + FURY approach to documentation work**: Documentation tasks and issues are maintained on our GitHub issue tracker for `DIPY <https://github.com/dipy/dipy/issues>`_ and `FURY <https://github.com/fury-gl/fury/issues>`_. Changes to the documentation are made via pull requests on GitHub, and reviewed with our standard review process which is the same for documentation and code (see `DIPY contributing guide <https://github.com/dipy/dipy/blob/master/CONTRIBUTING.md>`_ or `FURY contributing guide <http://fury.gl/latest/symlink/contributing.html>`_). Any new feature should be documented and followed by a tutorial. There is no dedicated "documentation manager" so every developer can review, improve, or comment on the improvement.
+
+Contact
+-------
+
+As a community-driven project we try to have all conversations about DIPY and FURY in public:
+
+- All discussions related to the *development* of DIPY (which includes GSoD) can occur on the `DIPY mailing list <https://mail.python.org/mailman3/lists/dipy.python.org/>`_. Please register and post to that list for discussing a GSoD proposal or idea. Also, you can use `our chat on gitter <https://gitter.im/nipy/dipy>`_.
+- All discussions related to the *development* of FURY (which includes GSoD) can occur on the `FURY mailing list <https://mail.python.org/mailman3/lists/fury.python.org/>`_. Please register and post to that list for discussing a GSoD proposal or idea. Also, you can use `our chat on Discord <https://discord.gg/6btFPPj>`_.
+
+Projects
+--------
+
+- **Project Idea 1**: *[DIPY] High-level restructuring and end-user focus.*
+- **Project Idea 2**: *[FURY] Create User and Developer Guides. Update missing docstrings/doctests*
+
+Projects in Details:
+====================
+
+Project idea 1: High-level restructuring and end-user focus
+-----------------------------------------------------------
+
+**Potential Mentors**: Ariel Rokem, Eleftherios Garyfallidis, Jon Haitz Legarreta Gorroño
+
+**Description**: DIPY serves many kinds of users: students that have a first time contact with the neuroimaging field, educators, researchers, medical doctors, software developers. In summary, DIPY's 10 year documentation needs to be reshaped and improved. We want to provide ways to guide those users to the parts of the documentation most relevant to them. We would love to work with a technical writer that can help us address this challenge.
+
+**Possible topics** include:
+
+- Improving the structure and content of https://dipy.org/
+- Reviewing and improving the structure of the documentation
+- Producing a roadmap or list of work items for engaging the community in further documentation work 
+- Rewriting the User and Developer Guides.
+- Adding non-textual images (illustrations, animations, graphics) to enhance the textual explanations
+- Improving consistency across the documentation.
+- Create documentation for the new command-line interface.
+
+Project idea 2: [FURY] Create User and Developer Guides. Update missing docstrings/doctests
+-------------------------------------------------------------------------------------------
+
+**Potential Mentors**: Serge Koudoro, Eleftherios Garyfallidis
+
+This project will be split into 2 parts:
+
+**Create User and Developer Guides**: Despite a lot of tutorials and demos, FURY is missing a User and Developer Guides to explain some basic concepts of our library. What is a vertex? What is a primitive? The technical writer will have to work closely with the core team to provide a boost to our current documentation and facilitate user learning and early adoption.
+
+**Missing docstrings/doctests**: Every public function in FURY should have a docstring with examples (doctests). At present few of them have an example on the docstring. The part of this project would consist of identifying which functions are missing documentation and adding them.

--- a/posts/2021/2021_01_15_serge_gsoc_announcement.rst
+++ b/posts/2021/2021_01_15_serge_gsoc_announcement.rst
@@ -1,0 +1,106 @@
+Google Summer of Code 2021
+==========================
+
+.. post:: January 15 2021
+     :author: Serge Koudoro
+     :tags: google
+     :category: gsoc announcement
+
+Introduction to DIPY
+====================
+
+DIPY is a free and open-source software library for the analysis of 3D/4D+ imaging in Python. It contains generic methods for spatial normalization, signal processing, machine learning, statistical analysis, and visualization of medical images. Additionally, it contains specialized methods for computational anatomy including diffusion, perfusion, and structural imaging. DIPY has many users from computational neuroanatomy and the medical data science field. DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging. DIPY is participating in GSoC this year for the 5th time.
+
+How to become a part of DIPY's Google Summer of Code 2021
+=========================================================
+
+GSoC is a program that allows students to learn by contributing to an open-source project while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://summerofcode.withgoogle.com/>`_. This year, DIPY is participating in GSoC under the umbrella of the International Neuroinformatics Coordinating Facility (`INCF <https://www.incf.org/>`_). More information can be found at INCF's `GSoC 2021 page <https://www.incf.org/training/gsoc>`_.
+
+Before considering becoming part of the DIPY GSoC, please read about our expectations.
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. However, you should be already familiar with data analysis using Python and Numpy before applying.
+
+Be happy to ask questions directly in our Gitter channel https://gitter.im/nipy/dipy
+
+Advice
+------
+
+Potential candidates should take a look at the guidelines on how to `contribute to DIPY <https://github.com/dipy/dipy/blob/master/CONTRIBUTING.md>`_. Making a small enhancement/bugfix/documentation fix/etc to DIPY already before applying for the GSoC can help you get some idea how things would work during the GSoC. The fix does not need to be related to your proposal. We have and will continue adding some beginner-friendly issues in Github. You can see some of them `here <https://github.com/dipy/dipy/issues>`_.
+
+Projects
+========
+
+Population-based MRI Template Creation
+--------------------------------------
+
+**Description:** Implement a method to create a population-based MRI template. Given an input of several subjects' MRI, create one standard template MRI for the population. The method will utilize the MRI registration framework available in DIPY.
+
+**Steps:** 
+
+* Understand MRI data
+* Implement template creation method
+* Write DIPY workflow of the method
+* Test it on different data sets
+
+**Difficulty:** Intermediate
+
+**Skills required:** Python, Image Registration, Image Processing.
+
+**Mentors:** `Bramsh Qamar Chandio <mailto:bqchandi@iu.edu>`_, `Shreyas Fadnavis <mailto:shfadn@iu.edu>`_, and `Jong Sung Park <mailto:jp109@iu.edu>`_
+
+Population-specific Tractography Bundle Atlas Creation
+------------------------------------------------------
+
+**Description:** Implement a method to create a population-specific Tractography Bundle Atlas. Given an input of several subjects' segmented white matter tracts, create one standard atlas of bundles for the population. The method will utilize the streamline-based registration framework available in DIPY.
+
+**Steps:** 
+
+* Understand Diffusion Tensor Imaging and Tractography data
+* Implement Bundle Atlas creation method
+* Write DIPY workflow of the method
+* Test it on different data sets
+
+**Difficulty:** Hard
+
+**Skills required:** Python, Registration.
+
+**Skills preferred:** Experience with Diffusion Tensor Imaging
+
+**Mentors:** `Bramsh Qamar Chandio <mailto:bqchandi@iu.edu>`_, `Shreyas Fadnavis <mailto:shfadn@iu.edu>`_, and `Jong Sung Park <mailto:jp109@iu.edu>`_
+
+Extend DIPY Horizon workflow for Visualization
+----------------------------------------------
+
+**Description:** Extend ``dipy_horizon`` workflow by adding more options for the visualization of the diffusion data. DIPY Horizon is a workflow that enables to visualize diffusion data such as dMRI, tractograms, white matter bundles, and more from the command line. This project requires student to add support for different types of file formats and visualizations in the horizon workflow. 
+
+**Steps:** 
+
+* Add support to visualize orientation distribution functions (odfs) generated from diffusion data
+* Create an option in the horizon workflow to project anatomical measures such as functional anisotropy (FA), mean diffusivity (MD), etc on the white matter tracts and visualize them
+* Add region-of-interest (ROI) capacity for streamline filtering in Horizon.
+* Add Qt functionality in dipy_horizon workflow
+
+**Difficulty:** Intermediate
+
+**Skills required:** Python, VTK, Qt. 
+
+**Mentors:** `Bramsh Qamar Chandio <mailto:bqchandi@iu.edu>`_, `Shreyas Fadnavis <mailto:shfadn@iu.edu>`_, and `Jong Sung Park <mailto:jp109@iu.edu>`_
+
+DIPY-Tract-or-Treat: DIPY DTI Post-Processing Pipeline 
+------------------------------------------------------
+
+**Description:** DIPY has several methods for reconstruction, tractography, bundle extraction, and tratometry. The idea of this project is to combine them all into one command-line interface that does reconstruction, tractography, bundle extraction, and bundle analytics. Users will have the option to select among different methods and design their pipeline from the list of available options.
+
+**Steps:** 
+
+* Understand DIPY and its workflows thoroughly
+* Create a command-line interface (workflow) to create a pipeline of different existing methods.
+* Test in on data
+
+**Difficulty:** Intermediate
+
+**Skills required:** Python
+
+**Skills preferred:** Experience with Diffusion Tensor Imaging
+
+**Mentors:** `Bramsh Qamar Chandio <mailto:bqchandi@iu.edu>`_, `Shreyas Fadnavis <mailto:shfadn@iu.edu>`_, and `Jong Sung Park <mailto:jp109@iu.edu>`_

--- a/posts/2022/2022_04_05_serge_gsoc_announcement.rst
+++ b/posts/2022/2022_04_05_serge_gsoc_announcement.rst
@@ -1,0 +1,83 @@
+Google Summer of Code 2022
+==========================
+
+.. post:: April 05 2022
+     :author: Serge Koudoro
+     :tags: google
+     :category: gsoc announcement
+
+Introduction to DIPY
+====================
+
+DIPY is a free and open-source software library for the analysis of 3D/4D+ imaging in Python. It contains generic methods for spatial normalization, signal processing, machine learning, statistical analysis, and visualization of medical images. Additionally, it contains specialized methods for computational anatomy including diffusion, perfusion, and structural imaging. DIPY has many users from computational neuroanatomy and the medical data science field. DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging. DIPY is participating in GSoC this year for the 7th time.
+
+How to become a part of DIPY's Google Summer of Code 2022
+=========================================================
+
+GSoC is a program that allows students to learn by contributing to an open-source project while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://summerofcode.withgoogle.com/>`_. This year, DIPY is participating in GSoC under the umbrella of the International Neuroinformatics Coordinating Facility (`INCF <https://www.incf.org/>`_). More information can be found at INCF's `GSoC 2022 page <https://www.incf.org/training/gsoc>`_.
+
+Before considering becoming part of the DIPY GSoC, please read about our expectations.
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. However, you should be already familiar with data analysis using Python and Numpy before applying.
+
+Be happy to ask questions directly in our Gitter channel https://gitter.im/nipy/dipy
+
+Advice
+------
+
+Potential candidates should take a look at the guidelines on how to `contribute to DIPY <https://github.com/dipy/dipy/blob/master/CONTRIBUTING.md>`_. Making a small enhancement/bugfix/documentation fix/etc to DIPY already before applying for the GSoC can help you get some idea how things would work during the GSoC. The fix does not need to be related to your proposal. We have and will continue adding some beginner-friendly issues in Github. You can see some of them `here <https://github.com/dipy/dipy/issues>`_.
+
+Projects
+========
+
+GPU parallelization of DIPY algorithms
+--------------------------------------
+
+**Description:** We have multiple versions of GPU parallelized algorithms. The project will be bringing those together in a common framework and adding new methods as well. For example, we currently have cudipy and GPU streamlines. A unified framework is required. In addition, we will need to parallelize some algorithms such as those used for probabilistic tractography and nonrigid registration.
+
+**Difficulty:** Intermediate
+
+**Time:** Full time
+
+**Skills required:** CUDA, C/C++, Python
+
+**Mentors:** Shreyas Fadnavis, Jongsung Park, Bramsh Qamar Chandio (contact via gitter or incf neurostar)
+
+A pythonic implementation of topup
+----------------------------------
+
+**Description:** A popular request is to bring topup [1] in a simple pythonic implementation that can be easily extended. The student will work on implementing topup (or similar function) from the ground up using Python, Cython and Numpy.
+
+**Difficulty:** Hard
+
+**Time:** Full time
+
+**Skills required:** Strong familiarity with diffusion MRI, Python, Numpy, Cython or C/C++
+
+**Mentors:** Jongsung Park, Shreyas Fadnavis, Bramsh Qamar Chandio (contact via gitter or incf neurostar)
+
+Extend DIPY Horizon workflow for Visualization
+----------------------------------------------
+
+**Description:** Extend dipy_horizon workflow by adding more options for the visualization and cleaning of tractograms generated from diffusion MRI data. DIPY Horizon is a workflow that enables to visualize diffusion data such as dMRI, tractograms, white matter bundles, and more from the command line. This project requires students to add support for different types of file formats and visualizations in the horizon workflow. Students will work on adding multiple features to help manual cleaning of streamlines such as select and remove streamlines from a bundle, cut some parts of the bundle and so on.
+
+**Difficulty:** Intermediate
+
+**Time:** Full time
+
+**Skills required:** Python, OpenGL, VTK
+
+**Mentors:** Bramsh Qamar Chandio, Shreyas Fadnavis, and Jong Sung Park (contact via gitter or incf neurostar)
+
+Add mutual information for non-rigid registration 
+-------------------------------------------------
+
+**Description:** Currently mutual information (MI) similarity metric is available only for affine registration and not nonrigid registration. The student will need to implement, compare and test MI for nonrigid registration. The existing implementation provides examples for SSD and Expectation Maximization metrics. The MI method is expected to work slightly better than our existing EM method for multimodal images. This project will focus on multimodal images. If time is permitted the student can also investigate a tensor based metric for registration.
+
+**Difficulty:** Beginner
+
+**Time:** Half time
+
+**Skills required:** Familiarity with registration algorithms, Python, Cython or C/C++.
+
+**Mentors:** Bramsh Qamar Chandio, Shreyas Fadnavis, Jong Sung Park (contact via gitter or incf neurostar)

--- a/posts/2023/2023_02_02_serge_gsoc_announcement.rst
+++ b/posts/2023/2023_02_02_serge_gsoc_announcement.rst
@@ -1,0 +1,171 @@
+Google Summer of Code 2023
+==========================
+
+.. post:: February 02 2023
+     :author: Serge Koudoro
+     :tags: google
+     :category: gsoc announcement
+
+Introduction to DIPY
+====================
+
+DIPY is a free and open-source software library for the analysis of 3D/4D+ imaging in Python. It contains generic methods for spatial normalization, signal processing, machine learning, statistical analysis, and visualization of medical images. Additionally, it contains specialized methods for computational anatomy including diffusion, perfusion, and structural imaging. DIPY has many users from computational neuroanatomy and the medical data science field. DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging. DIPY is participating in GSoC this year for the 7th time.
+
+How to become a part of DIPY's Google Summer of Code 2023
+=========================================================
+
+GSoC is a program that allows students to learn by contributing to an open-source project while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://summerofcode.withgoogle.com/>`_. 
+
+Before considering becoming part of the DIPY GSoC, please read about our expectations.
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. However, you should be already familiar with data analysis using Python and Numpy before applying.
+
+Be happy to ask questions directly in our:
+
+- Gitter channel https://gitter.im/dipy/dipy
+- Forum https://github.com/dipy/dipy/discussions
+
+Advice
+------
+
+Potential candidates should take a look at the guidelines on how to `contribute to DIPY <https://github.com/dipy/dipy/blob/master/CONTRIBUTING.md>`_. Making a small enhancement/bugfix/documentation fix/etc to DIPY already before applying for the GSoC can help you get some idea how things would work during the GSoC. The fix does not need to be related to your proposal. We have and will continue adding some beginner-friendly issues in Github. You can see some of them `here (beginner-friendly issues) <https://github.com/dipy/dipy/issues?q=is%3Aissue+is%3Aopen+label%3ABeginner-friendly>`_  or all the issues `here (all issues) <https://github.com/dipy/dipy/issues>`_.
+
+Project Ideas (7)
+=================
+
+**Notice 1:** More project ideas might appear **Stay tuned and check regularly this page!**
+
+**Notice 2:** We want to provide the best mentoring to our students, **only 2 or 3 of these projects will be selected.** Not more! 
+
+If you have any questions or if you want to contact a mentor:
+
+- `open a new discussion <https://github.com/dipy/dipy/discussions/new>`_ with GSOC as a category.
+
+Project 1. Add mutual information for non-rigid registration 
+------------------------------------------------------------
+
+**Difficulty:** Beginner / Intermediate
+
+**Mentors:** Serge Koudoro, Jong Sung Park (contact via github discussion)
+
+**Description:**
+
+Currently mutual information (MI) similarity metric is available only for affine registration and not nonrigid registration. The student will need to implement, compare and test MI for nonrigid registration. The existing implementation provides examples for SSD and Expectation Maximization metrics. The MI method is expected to work slightly better than our existing EM method for multimodal images. This project will focus on multimodal images. If time is permitted the student can also investigate a tensor based metric for registration.
+
+**Time:** Part-time (175 hours) or Full-Time (350 hours)
+
+**Skills required:** Familiarity with registration algorithms, Python, Cython or C/C++.
+
+Project 2. Generalized along tract analysis of fiber orientation dispersion
+---------------------------------------------------------------------------
+
+**Difficulty:** Intermediate
+
+**Mentors:** Rafael Neto Henriques, Julio Villalón  (contact via github discussion)
+
+**Description:** 
+
+Modeling the fiber orientation dispersion (OD) in the brain's white matter (WM) has been one of the long-standing goals of diffusion MRI (dMRI). The must common way to estimate OD is to apply biophysical models to diffusion MRI data acquired with multiple b-values (multi-shell acquisitions). Nevertheless, a vast amount of clinical dMRI data currently available worldwide is acquired using a single b-value (single-shell acquisitions). In this project, the student will need to implement OD estimation algorithms compatible to both single-shell and multi-shell acquisitions. These implementations should be integrated with the current reconstruction procedures in the Diffusion in Python (DIPY) library and they should be compatible with DIPY's unique along tract analysis.
+
+**Time:** Full-time (350 hours)
+
+**Skills required:** Familiarity with Python, experience with diffusion MRI would be a plus.
+
+Project 3. Correlation Tensor Magnetic Resonance Imaging
+--------------------------------------------------------
+
+**Difficulty:** Intermediate
+
+**Mentors:** Rafael Neto Henriques, Shreyas Fadnavis (contact via github discussion)
+
+**Description:** 
+
+Typical diffusion MRI techniques uses different phenomenological and mechanistic models to infer microscopic tissue properties from conventional diffusion MRI acquisitions. Recent studies show, however, that advanced diffusion encoding sequences can provide unique information not accessible from more conventional acquisition approaches [1]. In this project, the student will implement a recently proposed diffusion MRI technique for advanced diffusion MRI acquisitions, termed the Correlation Tensor Magnetic Resonance Imaging [2, 3]. This technique allows the estimation of specific sources of tissue non-Gaussian diffusion free from tissue model assumptions. 
+
+**Time:** Full-time (350 hours)
+
+**Skills required:** Familiarity with Python, experience with diffusion MRI with be a plus.
+
+**Related References and Links:**
+
+[1] Henriques, R.N., Palombo, M., Jespersen, S.N., Shemesh, N., Lundell, H., Ianuş , A., 2021. Double diffusion encoding and applications for biomedical imaging. J. Neurosci. Methods, 108989 doi: 10.1016/j.jneumeth.2020.108989
+
+[2] Henriques, R.N., Jespersen, S.N., Shemesh, N., 2020. Correlation tensor magnetic resonance imaging. Neuroimage 211. doi: 10.1016/j.neuroimage.2020.116605
+
+[3] Henriques, R.N., Jespersen, S.N., Shemesh, N., 2021. Evidence for microscopic kurtosis in neural tissue revealed by correlation tensor MRI. Magn. Reson. Med. 1–20. doi: 10.1002/mrm.28938 .
+
+Project 4. Creating Synthetic MRI data
+--------------------------------------
+
+**Difficulty:** Hard
+
+**Mentors:** Jong Sung Park, Serge Koudoro (contact via github discussion)
+
+**Description:**
+
+Diffusion models have been a state-of-the-art technique in the image generation area. While a lot of work has been done in the Computer Vision field, there has been limited work on conditional image generation of MRI data. Since it is relatively hard to acquire conditioned brain image data, various research can benefit from the synthetic dataset. The student will work on creating a conditioned diffusion model to generate brain MRI. The conditions can be, but not limited to, different modalities, existence/location of tumor/lesions, pediatric/adult, etc.
+
+**Time:** Full-time (350 hours)
+
+**Skills Required:** Python, Tensorflow or Pytorch (Tensorflow preferred), some familiarity on MRI.
+
+Project 5. An optimal pythonic implementation of Susceptibility Distortion Correction using AP PA data
+------------------------------------------------------------------------------------------------------
+
+**Difficulty:** Hard
+
+**Mentors:** Sreekar Chigurupati, Jong Sung Park (contact via github discussion)
+
+**Description:**
+
+A popular request is to bring topup [4] in a simple pythonic implementation that can be easily extended. We will provide an unoptimized version for reference. The student will work on optimizing topup (or similar function) using Python, Cython and Numpy.
+
+**Time:** Full-time (350 hours)
+
+**Skills Required:** Strong familiarity with diffusion MRI, Python, Numpy, Cython or C/C++
+
+**Related References and Links:**
+
+[4] J.L.R. Andersson, S. Skare, J. Ashburner. How to correct susceptibility distortions in spin-echo echo-planar images: application to diffusion tensor imaging. NeuroImage, 20(2):870-888, 2003.
+
+Project 6. DIPY algorithms Optimizations
+----------------------------------------
+
+**Difficulty:** Intermediate
+
+**Mentors:** Serge Koudoro, Jongsung Park (contact via github discussion)
+
+**Description:**
+
+Our algorithms performance can be easily be improved via somealgorithms trick and auto-vectorization. To realize this, the project will make sure that our current code is "auto-vectorization" friendly for any C compiler.  An extra step would be to parallelize via thread and CPU. In addition, an extra GPU component can be added for a full-time project if the student feel comfortable and confident with this technology. For example, we currently have cudipy and GPU streamlines. A unified framework is required. In addition, we will need to parallelize some algorithms such as those used for probabilistic tractography and nonrigid registration.
+
+**Project Steps**:
+
+ - Step 1: Look at pitfalls of our Registration framework and tractography framework.
+ - Step 2: Unroll many loop and simplify several Cython function.
+ - Step 3: Benchmark performance improvement.
+ - Step 4: Research for new algorithm tricks, implement them. Also, implementation of multithreading/multiprocessing via openmp or MPI 
+ - Step 5 (optional): GPU study and improvement.
+
+**Time:** Full-time (350 hours) or Part-time (175 hours)
+
+**Skills Required:** Python, cython, math, algorithms, optimization, CUDA, openmp, MPI, SIMD, SIMT
+
+Project 7. Accelerated MRI viewer – Horizon
+-------------------------------------------
+
+**Difficulty:** Intermediate/Advanced
+
+**Mentors:** Sreekar Chigurupati, Jong Sung Park (contact via github discussion)
+
+**Description:**
+
+DIPY comes with a modern viewer for dMRI-related data - Horizon [6]. It can be used both via Python and CLI. The purpose of this project is to load multiple MR images as textures to use them for comparison in slicer viewers. The candidate is expected to use the FURY shader API to create a layer-by-layer visibility option to switch images as well as add functionality that changes the relative contrast. In addition, we will create functionality to reset the 3D view to coronal, sagittal, and horizontal views.
+
+**Time:** Part-time (175 hours) or Full-Time (350 hours)
+
+**Skills Required:** MRI, Python, DIPY Workflows, FURY, VTK, GLSL
+
+**Related References and Links:**
+
+[6] Garyfallidis E., M-A. Cote, B.Q. Chandio, S. Fadnavis, J. Guaje, R. Aggarwal, E. St-Onge, K.S. Juneja, S. Koudoro, D. Reagan, DIPY Horizon: fast, modular, unified and adaptive visualization, Proceedings of: International Society of Magnetic Resonance in Medicine (ISMRM), Montreal, Canada, 2019.

--- a/posts/2024/2024_01_10_serge_gsoc_announcement.rst
+++ b/posts/2024/2024_01_10_serge_gsoc_announcement.rst
@@ -1,0 +1,150 @@
+Google Summer of Code 2024
+==========================
+
+.. post:: January 10 2024
+     :author: Serge Koudoro
+     :tags: google
+     :category: gsoc announcement
+
+Introduction to DIPY
+====================
+
+DIPY is a free and open-source software library for the analysis of 3D/4D+ imaging in Python. It contains generic methods for spatial normalization, signal processing, machine learning, statistical analysis, and visualization of medical images. Additionally, it contains specialized methods for computational anatomy including diffusion, perfusion, and structural imaging. DIPY has many users from computational neuroanatomy and the medical data science field. DIPY is an international project which brings together scientists across labs and countries to share their state-of-the-art code and expertise in the same codebase, accelerating scientific research in medical imaging. DIPY is participating in GSoC this year for the 7th time.
+
+How to become a part of DIPY's Google Summer of Code 2024
+=========================================================
+
+GSoC is a program that allows students to learn by contributing to an open-source project while receiving a fellowship from Google, and mentorship from open-source software developers. For details about this year's GSoC, please refer to `this page <https://summerofcode.withgoogle.com/>`_. 
+
+Before considering becoming part of the DIPY GSoC, please read about our expectations.
+
+All participants should have basic knowledge of scientific computing and development in Python. For a comprehensive introduction to these topics, please refer to the book `Effective Computation in Physics <http://shop.oreilly.com/product/0636920033424.do>`_ by Katy Huff and Anthony Scopatz. However, you should be already familiar with data analysis using Python and Numpy before applying.
+
+Be happy to ask questions directly in our:
+
+- Gitter channel https://gitter.im/dipy/dipy
+- Forum https://github.com/dipy/dipy/discussions
+
+Advice
+------
+
+Potential candidates should take a look at the guidelines on how to `contribute to DIPY <https://github.com/dipy/dipy/blob/master/CONTRIBUTING.md>`_. Making a small enhancement/bugfix/documentation fix/etc to DIPY already before applying for the GSoC can help you get some idea how things would work during the GSoC. The fix does not need to be related to your proposal. We have and will continue adding some beginner-friendly issues in Github. You can see some of them `here (beginner-friendly issues) <https://github.com/dipy/dipy/issues?q=is%3Aissue+is%3Aopen+label%3ABeginner-friendly>`_  or all the issues `here (all issues) <https://github.com/dipy/dipy/issues>`_.
+
+Project Ideas
+=============
+
+**Notice 1:** More project ideas might appear **Stay tuned and check regularly this page!**
+
+**Notice 2:** We want to provide the best mentoring to our students, **only 2 or 3 of these projects will be selected.** Not more! 
+
+If you have any questions or if you want to contact a mentor:
+
+- `open a new discussion <https://github.com/dipy/dipy/discussions/new>`_ with GSOC as a category.
+  
+Project 1. Add mutual information for non-rigid registration
+------------------------------------------------------------
+
+**Difficulty:** Beginner
+
+**Mentors:** Sreekar Chigurupati, Serge Koudoro, Jong Sung Park (contact via github discussion)
+
+**Description:**
+
+Mutual information (MI) similarity metric is a metric for registering images that have different modalities or styles. Currently, the metric is available only for affine registration and not nonrigid registration. The student will need to implement, compare and test MI for nonrigid registration. An existing implementation in DIPY of different metrics will provide a guideline. An initial implementation separate from DIPY will be provided as well. This metric is expected to boost registration accuracy. This project will focus on multimodal images. If time is permitted the student can also investigate a tensor based metric for registration.
+
+**Time:** small (~90 hour projects) or medium (~175 hr projects)
+
+**Skills required:** Familiarity with registration algorithms, Python and some knowledge in Cython or C/C++.
+
+Project 2. CUDA non-rigid registration
+--------------------------------------
+
+**Difficulty:** Intermediate
+
+**Mentors:** Sreekar Chigurupati, Serge Koudoro, Jong Sung Park (contact via github discussion)
+
+**Description:**
+
+Non-rigid registration has a larger degree of freedom than affine registration, hence a more accurate registration output. However, this also means an increase in time complexity. In neuroimaging, it is always beneficial to have a faster preprocessing pipeline. The student will work implementing the current non-rigid registration algorithm in DIPY using CUDA, as part of the gpu acceleration projects of various DIPY algorithms. If time permits, the student can also investigate accelerating different algorithms such as tracking or segmentation.
+
+**Time:** medium (~175 hr projects) or large (~350 hour)
+
+**Skills required:** Familiarity with registration algorithms, Python and CUDA
+
+Project 3. DIPY algorithms Optimizations
+----------------------------------------
+
+**Difficulty:** Intermediate
+
+**Mentors:** Serge Koudoro, Jongsung Park (contact via github discussion)
+
+**Description:**
+
+Our algorithms performance can be easily be improved via some algorithms trick and auto-vectorization. To realize this, the project will make sure that our current code is "auto-vectorization" friendly for any C compiler.  An extra step would be to parallelize via thread and CPU. In addition, an extra GPU component can be added for a full-time project if the student feel comfortable and confident with this technology. For example, we currently have cudipy and GPU streamlines. A unified framework is required. In addition, we will need to parallelize some algorithms such as those used for probabilistic tractography and nonrigid registration.
+
+**Project Steps:**
+
+ - Step 1: Look at pitfalls of our Registration framework and Denoising framework.
+ - Step 2: Unroll many loop and simplify several Cython function.
+ - Step 3: Benchmark performance improvement.
+ - Step 4: Implementation of multithreading/multiprocessing via openmp or MPI 
+ - Step 5 (optional): GPU study and improvement. Research for new algorithm tricks and implement them
+
+**Time:** Full-time (350 hours) or Part-time (175 hours)
+
+**Skills Required:** Python, cython, math, algorithms, optimization, CUDA, openmp, MPI, SIMD, SIMT
+
+Project 4. Solving Issues in DIPY_HORIZON
+-----------------------------------------
+
+**Difficulty:** Beginner
+
+**Mentors:** Maharshi Gor, Serge Koudoro, Jong Sung Park (contact via github discussion)
+
+**Description:**
+
+Horizon is a highly efficient scientific visualization tool. While DIPY contributors have been upgrading the function to accommodate user feedback and fix bugs, there are still several issues that need to be solved. This project requires the student to modify the python code and work on the issue. It will be a great opportunity for them to get involved in an open-source project and possibly continue to work on such projects.
+
+**Time:** small (~90 hour projects)
+
+**Skills required:** Python
+
+Project 5. Project ideas using AI/ML in Diffusion MRI processing
+----------------------------------------------------------------
+
+**Difficulty:** Intermediate
+
+**Mentors:** Jong Sung Park,  Sreekar Chigurupati, Serge Koudoro (contact via github discussion)
+
+**Description:**
+
+While there are many techniques that provide good results in Diffusion MRI processing, in many cases the algorithm can be a time bottleneck in the pipeline due to the complex equations and following time complexity. This project is to support the research of students who are interested in a AI/ML project that uses diffusion MRI data. Once the project is concluded and if the model is ready, further support will be done for publishing and providing open source code.
+
+**Time:** medium (~175 hr projects) or large (~350 hour)
+
+**Skills Required:** Python, Some knowledge with diffusion MRI, experience with AI/ML and corresponding tools (e.g. Tensorflow, Pytorch, etc)
+
+Project 6. Modernize DIPY Codebase
+----------------------------------
+
+**Difficulty:** Beginner
+
+**Mentors:** Serge Koudoro, Maharshi Gor, Jong Sung Park
+
+**Description:**
+
+The primary objective is to implement key improvements, including transitioning to keyword-only arguments for a more robust and readable codebase. Additionally, the initiative aims to integrate lazy loading, enhancing the tool's efficiency by loading resources only when needed. This modernization effort reflects a commitment to maintainability, code clarity, and optimizing performance in DIPY, ensuring it remains at the forefront of scientific visualization tools in the Python ecosystem. Other potential tasks may include code refactoring, adopting best practices, and incorporating new features to further elevate DIPY's capabilities and user experience.
+
+**Project Steps:**
+
+ - Step 1: keyword-only arguments integration.
+ - Step 2: lazy loading implementation.
+ - Step 3: Improve and simplify the management of the current website.
+ - Step 4: Improve Issues and Pull Requests Triage + Triage automation.
+ - Step 5: Integrates multiple Github Actions to simplify the workflows.
+ - Step 6: Refactor some DIPY packages + Improves Docstring
+ - Step 7: Add Tutorials
+
+**Time:** Part-time (175 hours) or full-time (350 hours) project
+
+**Skills Required:** Python, Sphinx.


### PR DESCRIPTION
# GSOC Announcements as Blogposts

## Overview
This PR creates blogposts for the GSOC and GSOD announcements done over DIPY wiki.

## Issue
This PR fixes - [Issue 21](https://github.com/dipy/dipy.org/issues/21)

## Key Changes
- Blogposts have been created from DIPY wiki for the GSOC & GSOD Announcements
 
## Testing
- Verified all posts render correctly on the development server