### PR TITLE
NF: Added Sidebar to `blog.html`

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -481,14 +481,23 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'blog/**': [
-          'ablog/postcard.html', 'ablog/recentposts.html',
-          'ablog/tagcloud.html', 'ablog/categories.html',
-          'ablog/archives.html', ],
-          'posts/**': [
-          'ablog/postcard.html', 'ablog/recentposts.html',
-          'ablog/tagcloud.html', 'ablog/categories.html',
-          'ablog/archives.html', ]}
+html_sidebars = {
+    'blog/**': [
+        'ablog/postcard.html', 'ablog/recentposts.html',
+        'ablog/tagcloud.html', 'ablog/categories.html',
+        'ablog/archives.html',
+    ],
+    'posts/**': [
+        'ablog/postcard.html', 'ablog/recentposts.html',
+        'ablog/tagcloud.html', 'ablog/categories.html',
+        'ablog/archives.html',
+    ],
+    'blog': [
+        'ablog/postcard.html', 'ablog/recentposts.html',
+        'ablog/tagcloud.html', 'ablog/categories.html',
+        'ablog/archives.html',
+    ],
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
This PR adds sidebar to the `blog.html` page, as previously it was not there which caused harder navigation.
Now it's more user friendly and easier to navigate, with quick reach to categories, archives and tags.

<img width="1673" alt="image" src="https://github.com/user-attachments/assets/4c96704e-c15c-4d49-87fc-1ece04e913d3">
