### PR TITLE
BF: Sphinx Build Error

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -22,8 +22,8 @@ except ImportError:
 
 from packaging.version import Version
 import sphinx
-if Version(sphinx.__version__) < Version('2'):
-    raise RuntimeError('Need sphinx >= 2 for numpydoc to work correctly')
+if Version(sphinx.__version__) < Version('6') or Version(sphinx.__version__) >= Version('8'):
+    raise RuntimeError('Needs 8 > Sphinx Version >= 6  for numpydoc to work correctly')
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpydoc
-sphinx!=4.4
+sphinx==7.4.6
 tomli>=2.0.1
 grg-sphinx-theme>=0.3.2
 Jinja2


### PR DESCRIPTION
This PR fixes the error that is being generated due to mismatch of sphinx version.

We will need to work upon changes to accommodate the newer version of sphinx.

Linked Issue: https://github.com/dipy/dipy.org/issues/59