### PR TITLE
RF: Title and navigation fix

### DIFF
--- a/_templates/home.html
+++ b/_templates/home.html
@@ -1,5 +1,6 @@
 {# Extending the incoming html page to handle everything from pydata/grg theme #}
 {% extends "layout.html" %}
+{% set title = "DIPY" %}
 
 {# Reimplementing the main content #}
 {% block docs_main %}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,5 +1,5 @@
 {% extends "!layout.html" %}
-{% set title = 'DIPY' %}
+
 
 {% block rootrellink %}
   <li><a href="{{pathto('index')}}">Home</a> |&nbsp;</li>


### PR DESCRIPTION
This PR updates the navigation and title of the page according to the h1 tag (heading) on the page.

<img width="1440" alt="Screenshot 2025-02-07 at 11 31 32 PM" src="https://github.com/user-attachments/assets/bf0299d2-56ac-4960-94a6-2cddf78b695d" />
