### PR TITLE
RF: update deadlink

### DIFF
--- a/posts/2020/2020_05_04_serge_gsod_announcement.rst
+++ b/posts/2020/2020_05_04_serge_gsod_announcement.rst
@@ -37,11 +37,11 @@ About our Documentation
 +===================+================================================+================================================+
 | Latest version    | https://dipy.org                               | https://fury.gl                                |
 +-------------------+------------------------------------------------+------------------------------------------------+
-| tutorials         | https://dipy.org/tutorials/                    | http://fury.gl/latest/auto_tutorials/index.html|
+| tutorials         | https://dipy.org/tutorials                     | http://fury.gl/latest/auto_tutorials/index.html|
 +-------------------+------------------------------------------------+------------------------------------------------+
-| reference guide   | https://dipy.org/documentation/latest/reference| http://fury.gl/latest/reference/index.html     |
+| reference guide   | https://docs.dipy.org/stable/reference/  | http://fury.gl/latest/reference/index.html     |
 +-------------------+------------------------------------------------+------------------------------------------------+
-| developer docs    | https://dipy.org/documentation/latest/devel/   | http://fury.gl/latest/symlink/contributing.html|
+| developer docs    | https://docs.dipy.org/stable/devel/            | http://fury.gl/latest/symlink/contributing.html|
 +-------------------+------------------------------------------------+------------------------------------------------+
 | GitHub repository | https://github.com/dipy/dipy                   | https://github.com/fury-gl/fury                |
 +-------------------+------------------------------------------------+------------------------------------------------+
@@ -84,7 +84,7 @@ Project idea 1: High-level restructuring and end-user focus
 
 - Improving the structure and content of https://dipy.org/
 - Reviewing and improving the structure of the documentation
-- Producing a roadmap or list of work items for engaging the community in further documentation work 
+- Producing a roadmap or list of work items for engaging the community in further documentation work
 - Rewriting the User and Developer Guides.
 - Adding non-textual images (illustrations, animations, graphics) to enhance the textual explanations
 - Improving consistency across the documentation.

--- a/posts/2020/2020_12_05_Areesha.rst
+++ b/posts/2020/2020_12_05_Areesha.rst
@@ -137,7 +137,7 @@ Current State of the Project:
 
 Most of the documentation and the PRs that were made during the project have been merged and were included in the 1.3 release of DIPY (https://github.com/dipy/dipy/releases/tag/1.3.0). The last few PRs are also merged and will be included in the 1.4 release of DIPY (due by December, 28th 2020; https://github.com/dipy/dipy/milestone/8).
 
-Thanks to the documentation generated in the framework of the GSoD 2020, the DIPY CLI workflows have gained visibility, and have now their own section on DIPY's website (https://dipy.org/documentation/1.3.0./interfaces/). The workflows have started to attract the attention of the community, reflected by the increase in related questions posted in DIPY's gitter room (https://gitter.im/dipy/dipy).
+Thanks to the documentation generated in the framework of the GSoD 2020, the DIPY CLI workflows have gained visibility, and have now their own section on DIPY's website (https://docs.dipy.org/stable/interfaces/). The workflows have started to attract the attention of the community, reflected by the increase in related questions posted in DIPY's gitter room (https://gitter.im/dipy/dipy).
 
 Learnings and Challenges:
 -------------------------


### PR DESCRIPTION
This pull request updates several documentation links to point to the new stable documentation site for DIPY. The most important changes are:
