### PR TITLE
Underline blog post links by default

### DIFF
--- a/_static/css/common/override.css
+++ b/_static/css/common/override.css
@@ -14,3 +14,10 @@ override the pydata-theme and sphinx.
 .gsoc-title {
   color: #fd8d25 !important;
 }
+
+/* Theme only underlines links on hover, so inline links in blog post
+   body text are easy to miss. Underline them by default; skip buttons
+   and heading-anchor icons which have their own styling. */
+.bd-article a:not(.btn-link):not(.headerlink) {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Theme only underlines links on hover, making inline links in blog post body text hard to spot
- Underline links inside article content by default, excluding buttons (`.btn-link`) and heading-anchor icons (`.headerlink`)

## Test plan
- [ ] `make html` and check a blog post: links show underline without needing hover
- [ ] Verify buttons and heading-anchor (¶) icons still render unaffected